### PR TITLE
Add support to debug different mutations

### DIFF
--- a/scripts/build/setup_deps.sh
+++ b/scripts/build/setup_deps.sh
@@ -95,12 +95,18 @@ echo "  LLVM (asan) ready: $LLVM_BUILD_ASAN"
 # --- LLVM build: plain (for Alive2 + tools) ---
 LLVM_BUILD_PLAIN="$DEPS_DIR/llvm-build-plain"
 
-cmake -S "$LLVM_SRC/llvm" -B "$LLVM_BUILD_PLAIN" \
-    "${COMMON_CMAKE_FLAGS[@]}" \
-    -DCMAKE_BUILD_TYPE=Release \
-    -DLLVM_ENABLE_RTTI=ON
+if [ ! -f "$LLVM_BUILD_PLAIN/bin/opt" ] || [ ! -f "$LLVM_BUILD_PLAIN/bin/llvm-reduce" ]; then
+    echo "  Configuring LLVM (plain)..."
+    cmake -S "$LLVM_SRC/llvm" -B "$LLVM_BUILD_PLAIN" \
+        "${COMMON_CMAKE_FLAGS[@]}" \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DLLVM_ENABLE_RTTI=ON
 
-cmake --build "$LLVM_BUILD_PLAIN" --target opt -j"$JOBS"
+    echo "  Building LLVM (plain)..."
+    cmake --build "$LLVM_BUILD_PLAIN" --target opt llvm-reduce -j"$JOBS"
+else
+    echo "  LLVM (plain) already built, skipping."
+fi
 
 # --- Alive2 (built against sancov LLVM) ---
 echo "[4/4] Building Alive2..."

--- a/scripts/run/run_fuzzer.sh
+++ b/scripts/run/run_fuzzer.sh
@@ -43,7 +43,7 @@ FLAGS=(
     --address_space_limit_mb=0
     --corpus_dir="$CORPUS_DIR"
     --v=1
-    --max_num_crash_reports=10000
+    --max_num_crash_reports=50000
 )
 
 echo "[run] $CENTIPEDE_BIN ${FLAGS[*]} $*"

--- a/src/harness/opt_fuzz_target.cc
+++ b/src/harness/opt_fuzz_target.cc
@@ -16,15 +16,25 @@
 
 #include "src/mutators/registry.h"
 
+#include <chrono>
 #include <cstddef>
 #include <cstdint>
 #include <cstdio>
 #include <cstring>
+#include <ctime>
 #include <random>
 #include <string>
 
 static llvm::LLVMContext *Ctx = nullptr;
 static std::mt19937 *RNG = nullptr;
+
+// Centipede user-defined features: domain 0, feature id = mutation index + 1.
+// Zero entries are ignored by Centipede, so we reserve 0 for "no mutation".
+static constexpr size_t kNumExtraFeatures = 64;
+__attribute__((used, retain, section("__centipede_extra_features")))
+static uint64_t regatoni_extra_features[kNumExtraFeatures];
+
+static thread_local uint32_t g_last_mutation_id = 0;
 
 extern "C" size_t LLVMFuzzerMutate(uint8_t *Data, size_t Size, size_t MaxSize);
 
@@ -66,6 +76,14 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size) {
       PB.buildPerModuleDefaultPipeline(llvm::OptimizationLevel::O2);
 
   MPM.run(*M, MAM);
+
+  // Emit mutation identity as a Centipede user feature (domain 0).
+  // Upper 32 bits = domain id (0); lower 32 bits = mutation index + 1.
+  if (g_last_mutation_id != 0) {
+    regatoni_extra_features[0] =
+        (uint64_t{0} << 32) | uint64_t{g_last_mutation_id};
+    g_last_mutation_id = 0;
+  }
   return 0;
 }
 
@@ -79,7 +97,10 @@ extern "C" size_t LLVMFuzzerCustomMutator(uint8_t *Data, size_t Size,
       llvm::StringRef(reinterpret_cast<const char *>(Data), Size),
       "fuzz_input");
 
+  using Clock = std::chrono::steady_clock;
+  auto t_parse_start = Clock::now();
   auto M = llvm::parseIR(*Buf, Err, *Ctx);
+  auto t_parse_end = Clock::now();
   if (!M)
     return LLVMFuzzerMutate(Data, Size, MaxSize);
 
@@ -90,7 +111,9 @@ extern "C" size_t LLVMFuzzerCustomMutator(uint8_t *Data, size_t Size,
   fprintf(stderr, "CustomMutator: invoking applyRandom (Size=%zu, Seed=%u)\n",
           Size, Seed);
   fflush(stderr);
+  auto t_mut_start = Clock::now();
   std::string applied = reg.applyRandom(*M, rng);
+  auto t_mut_end = Clock::now();
   fprintf(stderr, "CustomMutator: applied mutation: '%s'\n", applied.c_str());
   fflush(stderr);
   if (applied.empty())
@@ -99,10 +122,53 @@ extern "C" size_t LLVMFuzzerCustomMutator(uint8_t *Data, size_t Size,
   if (llvm::verifyModule(*M, nullptr))
     return LLVMFuzzerMutate(Data, Size, MaxSize);
 
+  // Record which mutation ran, so LLVMFuzzerTestOneInput can emit it as a
+  // user feature. Index is position in the registry; +1 so that 0 (ignored
+  // by Centipede) means "no mutation recorded".
+  uint32_t mutation_id = 0;
+  const auto &all = reg.all();
+  for (size_t i = 0; i < all.size(); ++i) {
+    if (all[i]->name() == applied) {
+      mutation_id = static_cast<uint32_t>(i) + 1;
+      break;
+    }
+  }
+  g_last_mutation_id = mutation_id;
+
   std::string Out;
+  Out.reserve(Size + applied.size() + 32);
+  Out.append("; regatoni-mutation: ");
+  Out.append(applied);
+  Out.push_back('\n');
   llvm::raw_string_ostream OS(Out);
+  auto t_ser_start = Clock::now();
   M->print(OS, nullptr);
   OS.flush();
+  auto t_ser_end = Clock::now();
+
+  auto to_sec = [](Clock::duration d) {
+    return std::chrono::duration<double>(d).count();
+  };
+  double parse_s = to_sec(t_parse_end - t_parse_start);
+  double mut_s = to_sec(t_mut_end - t_mut_start);
+  double ser_s = to_sec(t_ser_end - t_ser_start);
+  if (parse_s > 2.0 || mut_s > 2.0 || ser_s > 2.0) {
+    if (FILE *f = std::fopen("build/slow_mutations.log", "a")) {
+      std::time_t now = std::time(nullptr);
+      char ts[32];
+      std::strftime(ts, sizeof(ts), "%Y-%m-%dT%H:%M:%S",
+                    std::gmtime(&now));
+      std::fprintf(f,
+                   "%s mutation=%s size=%zu parse=%.3fs mutate=%.3fs "
+                   "serialize=%.3fs hex=",
+                   ts, applied.c_str(), Size, parse_s, mut_s, ser_s);
+      size_t n = Size < 200 ? Size : 200;
+      for (size_t i = 0; i < n; ++i)
+        std::fprintf(f, "%02x", Data[i]);
+      std::fputc('\n', f);
+      std::fclose(f);
+    }
+  }
 
   if (Out.size() > MaxSize)
     return LLVMFuzzerMutate(Data, Size, MaxSize);


### PR DESCRIPTION
Some mutation compositions time out. For example, from the run logs we see - `MutateViaExternalBinary took 1m37s`. This PR is to add debugging to inspect this behavior.

Note: This is a development feature, and should be removed in the future.